### PR TITLE
use class instead of id for tooltips

### DIFF
--- a/src/radviz-component.js
+++ b/src/radviz-component.js
@@ -220,7 +220,7 @@ var radvizComponent = function() {
         var tooltipContainer = d3.select(config.el)
             .append('div')
             .attr({
-                id: 'radviz-tooltip'
+                class: 'radviz-tooltip'
             });
         var tooltip = tooltipComponent(tooltipContainer.node());
 


### PR DESCRIPTION
When using multiple `radviz` on a page, the `id` of tooltips will conflict in the `DOM`.  We can change to `class` with no adverse effects to eliminate this conflict.
